### PR TITLE
Add command-line calorie tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+calorie_data.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Jesse
+# Calorie Tracker
+
+This repository contains a simple command-line calorie tracking tool written in Python.
+
+## Usage
+
+```
+python3 calorie_tracker.py [command] [arguments]
+```
+
+### Commands
+- `log <amount>` – add calories to today.
+- `status` – show today's total and your current streak.
+- `end` – finalize today, check if you met your goal, and update the streak.
+- `setgoal <amount>` – change your daily calorie goal.
+
+The app stores data in `calorie_data.json` in the project directory.
+
+A streak of three consecutive days meeting your goal will trigger a message telling you that you've earned $20 to spend as you like.

--- a/calorie_tracker.py
+++ b/calorie_tracker.py
@@ -1,0 +1,87 @@
+import json
+from datetime import date
+from pathlib import Path
+
+DATA_FILE = Path('calorie_data.json')
+
+def load_data():
+    if DATA_FILE.exists():
+        with DATA_FILE.open() as f:
+            return json.load(f)
+    return {"goal": 2000, "streak": 0, "records": {}}
+
+def save_data(data):
+    with DATA_FILE.open('w') as f:
+        json.dump(data, f, indent=2)
+
+def log_calories(amount):
+    data = load_data()
+    d = str(date.today())
+    data['records'].setdefault(d, 0)
+    data['records'][d] += amount
+    save_data(data)
+    print(f"Logged {amount} calories for {d}.")
+
+def end_day():
+    data = load_data()
+    d = str(date.today())
+    total = data['records'].get(d, 0)
+    goal = data['goal']
+    if total >= goal:
+        data['streak'] += 1
+        print(f"Congrats! You hit your goal with {total} calories.")
+        if data['streak'] >= 3:
+            print("Streak is 3! You earned $20.")
+    else:
+        print(f"You only logged {total} calories, under the goal of {goal}.")
+        if data['streak'] != 0:
+            print("Streak reset.")
+        data['streak'] = 0
+    save_data(data)
+
+
+def show_status():
+    data = load_data()
+    d = str(date.today())
+    total = data['records'].get(d, 0)
+    goal = data['goal']
+    print(f"Today: {total}/{goal} calories")
+    print(f"Current streak: {data['streak']} day(s)")
+
+
+def set_goal(amount):
+    data = load_data()
+    data['goal'] = amount
+    save_data(data)
+    print(f"New daily goal set to {amount} calories.")
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Simple calorie tracker")
+    subparsers = parser.add_subparsers(dest='command')
+
+    log_parser = subparsers.add_parser('log', help='Log calories for today')
+    log_parser.add_argument('amount', type=int, help='Calories to add')
+
+    subparsers.add_parser('status', help='Show today\'s progress')
+    subparsers.add_parser('end', help='Finalize today and update streak')
+
+    goal_parser = subparsers.add_parser('setgoal', help='Set new calorie goal')
+    goal_parser.add_argument('amount', type=int)
+
+    args = parser.parse_args()
+
+    if args.command == 'log':
+        log_calories(args.amount)
+    elif args.command == 'status':
+        show_status()
+    elif args.command == 'end':
+        end_day()
+    elif args.command == 'setgoal':
+        set_goal(args.amount)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document usage instructions in `README.md`
- add a simple calorie tracking script
- ignore runtime data file

## Testing
- `python3 calorie_tracker.py status`
- `python3 calorie_tracker.py log 500`
- `python3 calorie_tracker.py end`
- `python3 calorie_tracker.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_686bebdddeb8832a9b47e92ddf130f02